### PR TITLE
fix: update renovate configuration to disable docker matcher

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sparkfabrik/renovatebot-default-configuration"]
+  "extends": ["github>sparkfabrik/renovatebot-default-configuration"],
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile"],
+      "description": "Disable all Docker updates because the versions must be checked manually (gcloud alpine version, python version, etc.).",
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Disable automatic Docker updates in Renovate configuration

- Add package rule to prevent Dockerfile dependency updates

- Require manual version checks for Docker images (gcloud, python)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["renovate.json"] --> B["Add packageRules"]
  B --> C["Disable dockerfile manager"]
  C --> D["Manual version control"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Disable Docker dependency auto-updates in Renovate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renovate.json

<ul><li>Added <code>packageRules</code> section to configuration<br> <li> Disabled automatic updates for Dockerfile manager<br> <li> Added descriptive comment explaining manual version check requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-alpine-aws-cli/pull/28/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

