### PR TITLE
chore(deps): upgrade aws-cli to 2.35.15 and add alpine 3.23 support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         tag:
           # To keep the number of builds low, we only keep the latest two versions of the AWS CLI
+          - 2.35.15-3.12.13-3.23
+          - 2.35.15-3.12.4-3.20
+          - 2.33.2-3.12.13-3.23
           - 2.33.2-3.12.4-3.20
-          - 2.33.2-3.12.4-3.19
-          - 2.31.17-3.12.4-3.20
-          - 2.31.17-3.12.4-3.19
     steps:
       - uses: actions/checkout@v6
 
@@ -69,10 +69,10 @@ jobs:
       matrix:
         tag:
           # To keep the number of builds low, we only keep the latest two versions of the AWS CLI
+          - 2.35.15-3.12.13-3.23
+          - 2.35.15-3.12.4-3.20
+          - 2.33.2-3.12.13-3.23
           - 2.33.2-3.12.4-3.20
-          - 2.33.2-3.12.4-3.19
-          - 2.31.17-3.12.4-3.20
-          - 2.31.17-3.12.4-3.19
     steps:
       - uses: actions/checkout@v6
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,167 @@
+# AGENTS.md
+
+## Project Overview
+
+Builds a Docker image that compiles the AWS CLI v2 from source on Alpine Linux. The compiled binary is published to GitHub Container Registry (`ghcr.io/sparkfabrik/docker-alpine-aws-cli`) so downstream Alpine images can copy `aws` in via a multi-stage `COPY --from=`.
+
+The `Dockerfile` is a two-stage build: a `python:*-alpine*` builder stage clones `aws/aws-cli` at a pinned tag, compiles it with `make-exe`, and installs it; the final `alpine` stage carries only the compiled CLI plus `bash` and `groff`.
+
+**Tech stack:** Docker (multi-stage, buildx), Alpine Linux, Python (builder stage only, to compile AWS CLI v2), Make, GitHub Actions.
+
+## Setup
+
+Everything runs in Docker via `make` and `docker buildx`. No local Python or AWS CLI required.
+
+```bash
+make build                 # Build the default (latest) tag: 2.35.15-alpine3.23
+make print-latest-image-tag # Print the LATEST_VERSION used by CI to tag `latest`
+```
+
+Individual version combinations are built with their own targets:
+
+```bash
+make build-2.35.15-3.23    # AWS CLI 2.35.15, Python 3.12.13, Alpine 3.23
+make build-2.35.15-3.20    # AWS CLI 2.35.15, Python 3.12.4,  Alpine 3.20
+make build-2.33.2-3.23
+make build-2.33.2-3.20
+```
+
+The Alpine 3.23 base ships Python 3.12 without `distutils`, which aws-cli's `make-exe`
+still imports; the Dockerfile installs `setuptools<74` in the builder to restore it.
+
+Each target sets `AWS_CLI_VERSION`, `PYTHON_VERSION`, `ALPINE_VERSION` and calls `build-template`, which runs `docker buildx build --load` with those build args.
+
+## Key Conventions
+
+- **Docker-only.** All builds go through `docker buildx`. Never install the AWS CLI or Python locally to test.
+- **Versions are pinned in three places that must agree:**
+  - `Dockerfile` `ARG` defaults (`PYTHON_VERSION`, `ALPINE_VERSION`, `AWS_CLI_VERSION`).
+  - `Makefile` per-target overrides and `LATEST_VERSION`.
+  - The CI matrix in `.github/workflows/docker-publish.yml` (tag format `<awscli>-<python>-<alpine>`).
+    A version bump touches all three.
+- **Keep the build matrix small.** By project policy only the latest two AWS CLI versions are kept (see comments in the Makefile and workflow). Drop the oldest when adding a new one.
+- **AWS CLI v1 lives on the `v2` branch note.** The Dockerfile comment points to a `v2` branch for v2 docs; the current build compiles v2 from the pinned git tag.
+- The build deletes unused `completions-1*.json` and `examples-1.json` data files to shrink the image — preserve that cleanup when editing the builder stage.
+
+## Git Workflow
+
+### Commits
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```
+<type>(<scope>): <description>
+```
+
+**Types:** `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf`, `build`.
+**Scope** is optional — use the affected component (e.g. `deps`).
+
+Keep the description lowercase, imperative, no period. This repo uses the `sf-commit-convention` skill — consult it before every commit.
+
+### Branching
+
+- Branch naming: `feat/`, `fix/`, `chore/`, `test/`, `docs/` prefix + kebab-case description (e.g. `feat/upgrade-awscli-2.34`, `fix/install-bash`).
+- **Never push directly to `main`.** Always create a feature branch and open a pull request.
+
+### Rebasing
+
+- Always rebase onto `main` before pushing. No merge commits.
+- Use `--force-with-lease` (never `--force`) after rebasing.
+- Rebase before the first push, before opening a PR, and whenever `main` advances.
+
+## Version Management
+
+This repo has no language package manager — dependencies are pinned versions of external components.
+
+- **AWS CLI version:** the git tag cloned in the Dockerfile builder stage. Set via `AWS_CLI_VERSION` in the Makefile targets and Dockerfile `ARG`.
+- **Python / Alpine versions:** base image tags, pinned via `PYTHON_VERSION` / `ALPINE_VERSION`.
+- **GitHub Actions:** managed by Renovate (`renovate.json` extends `sparkfabrik/renovatebot-default-configuration`).
+- **Dockerfile updates are Renovate-disabled on purpose** (`renovate.json`) — base image and AWS CLI versions must be checked and bumped manually.
+
+### Dependency Safety
+
+Before bumping any pinned version, verify it against the live source:
+
+1. **Never assume you know the latest version.** Your training data is outdated. Always check the live source before bumping.
+2. **Check the live source:**
+
+   AWS CLI (git tags):
+
+   ```bash
+   git ls-remote --tags --refs https://github.com/aws/aws-cli.git | awk -F/ '{print $NF}' | grep '^2\.' | sort -V | tail -5
+   ```
+
+   Python Alpine image tags (Docker Hub):
+
+   ```bash
+   curl -s "https://hub.docker.com/v2/repositories/library/python/tags?page_size=100&name=alpine" | jq -r '.results[].name' | grep alpine | head
+   ```
+
+   Alpine image tags:
+
+   ```bash
+   curl -s "https://hub.docker.com/v2/repositories/library/alpine/tags?page_size=50" | jq -r '.results[].name' | sort -V | tail
+   ```
+
+3. **Verify the AWS CLI tag actually builds** on the chosen Python + Alpine combination before committing — the compile step (`make-exe`) is version-sensitive.
+4. **Update all three locations** (Dockerfile ARG, Makefile, CI matrix) in the same change and keep the matrix to the latest two AWS CLI versions.
+
+## Build Gotchas
+
+- The Python patch version is coupled to the Alpine minor. Only `python:<patch>-alpine<minor>` tags that exist on Docker Hub are usable. `python:3.12.4-alpine3.23` does not exist; Alpine 3.20 has no Python newer than `3.12.10`; Alpine 3.23 has `3.12.13`. Check Docker Hub for the pair before choosing a `PYTHON_VERSION` — you cannot pin an arbitrary Python patch against an arbitrary Alpine minor.
+- aws-cli's `make-exe` imports `distutils`, which the Python 3.12 stdlib no longer ships. Older Alpine Python images built anyway because their bundled `setuptools` shimmed `distutils`; `setuptools >= 74` (shipped by the Alpine 3.23 Python image) dropped that shim. The builder installs `setuptools<74` to restore it. Removing that line breaks the build with `ModuleNotFoundError: No module named 'distutils'`.
+- aws-cli 2.33.2 prints `UserWarning: pkg_resources is deprecated as an API` on stderr for every command. It is benign and was fixed upstream by 2.35.x. `PYTHONWARNINGS` does not suppress it — the frozen PyInstaller binary emits it during bootstrap, before any warning filter applies. Do not spend time silencing it; it ages out when 2.33.2 leaves the latest-two window.
+- `RUN . venv/bin/activate` in the Dockerfile is a no-op. Each `RUN` is a fresh shell, so the activation does not carry to the next layer. `make-exe` manages its own venv internally, so the line has no effect either way.
+- Build every matrix combination locally before committing a version bump. The compile step is version-sensitive, so a change that builds for one AWS CLI / Python / Alpine triple can still fail for another.
+
+## Testing
+
+There is no unit test suite. Verification is the build itself.
+
+- Locally: `make build-<version>` must complete, and the builder stage runs `aws --version` as a smoke check.
+- In CI: the `test` job (`.github/workflows/docker-publish.yml`) builds every matrix tag with `push: false` on pull requests and non-`main` branches.
+
+## CI/CD
+
+GitHub Actions workflow `.github/workflows/docker-publish.yml` (`Docker`), triggered on pull requests and pushes to `main`.
+
+### Key Jobs
+
+| Job      | Runs when                   | Purpose                                                                                                                                  |
+| -------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `test`   | ref is not `main`           | Build each matrix tag with `--load`, `push: false` — validates the build.                                                                |
+| `deploy` | ref is `main` (or `master`) | Build for `linux/amd64,linux/arm64` and push to `ghcr.io`. Logs in via `docker/login-action` pinned by commit SHA, using `GITHUB_TOKEN`. |
+
+Tagging (via `docker/metadata-action`): each version gets a `<awscli>-alpine<alpine>` tag; the version matching `LATEST_VERSION` (from `make print-latest-image-tag`) also gets `latest`; every build gets a `sha`-suffixed tag.
+
+## Command Safety
+
+### Safe (run autonomously)
+
+- `make print-latest-image-tag`
+- `make build`, `make build-<version>` (local build only, `--load`, no push)
+- `git status`, `git log`, `git diff`
+- The registry/version check commands in Dependency Safety.
+
+### Dangerous (ask user first)
+
+- `git push`, opening or merging a pull request.
+- Any manual `docker push` to `ghcr.io`.
+- Version bumps to AWS CLI / Python / Alpine (change what gets published).
+- Editing the CI matrix.
+
+### Destructive (never run)
+
+- `git push --force` (use `--force-with-lease`).
+- Deleting published image tags from the registry.
+- `docker system prune -af` or similar host-wide teardown.
+
+## Important Rules
+
+- Everything builds in Docker via `make` + `buildx` — never install AWS CLI or Python locally.
+- A version bump must update the Dockerfile ARG, the Makefile, and the CI matrix together.
+- Keep only the latest two AWS CLI versions in the build matrix.
+- Verify any version against its live source before bumping — Dockerfile updates are deliberately Renovate-disabled.
+- Never push to `main`; branch and open a PR.
+- Follow conventional commits via the `sf-commit-convention` skill.
+- Rebase onto `main`, use `--force-with-lease`, never `--force`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG AUTHOR
 ARG PYTHON_VERSION=3.12.4
 ARG ALPINE_VERSION=3.20
 ARG IMAGE_NAME=spark-alpine-aws-cli
-ARG AWS_CLI_VERSION=2.33.2
+ARG AWS_CLI_VERSION=2.35.15
 
 # Build process
 # If you want to see the AWS CLI v2 documentation, remember to go to the `v2` branch.
@@ -18,6 +18,9 @@ RUN git clone --single-branch --depth 1 -b ${AWS_CLI_VERSION} https://github.com
 WORKDIR /aws-cli
 RUN python -m venv venv
 RUN . venv/bin/activate
+# aws-cli's make-exe still imports distutils, removed from the Python 3.12 stdlib.
+# setuptools < 74 vendors a distutils shim; newer Alpine Python images ship setuptools >= 74 without it.
+RUN pip install --no-cache-dir --break-system-packages "setuptools<74"
 RUN scripts/installers/make-exe
 RUN unzip -q dist/awscli-exe.zip
 RUN aws/install --bin-dir /aws-cli-bin

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,30 @@
 AUTHOR ?= sparkfabrik
 IMAGE_NAME ?= docker-alpine-aws-cli
 PLATFORM ?= "linux/amd64"
-LATEST_VERSION ?= 2.33.2-alpine3.20
+LATEST_VERSION ?= 2.35.15-alpine3.23
 
-build: build-2.33.2-3.20
+build: build-2.35.15-3.23
 
 # To keep the number of builds low, we only keep the latest two versions of the AWS CLI
+build-2.35.15-3.23: AWS_CLI_VERSION="2.35.15"
+build-2.35.15-3.23: PYTHON_VERSION="3.12.13"
+build-2.35.15-3.23: ALPINE_VERSION="3.23"
+build-2.35.15-3.23: build-template
+
+build-2.35.15-3.20: AWS_CLI_VERSION="2.35.15"
+build-2.35.15-3.20: PYTHON_VERSION="3.12.4"
+build-2.35.15-3.20: ALPINE_VERSION="3.20"
+build-2.35.15-3.20: build-template
+
+build-2.33.2-3.23: AWS_CLI_VERSION="2.33.2"
+build-2.33.2-3.23: PYTHON_VERSION="3.12.13"
+build-2.33.2-3.23: ALPINE_VERSION="3.23"
+build-2.33.2-3.23: build-template
+
 build-2.33.2-3.20: AWS_CLI_VERSION="2.33.2"
 build-2.33.2-3.20: PYTHON_VERSION="3.12.4"
 build-2.33.2-3.20: ALPINE_VERSION="3.20"
 build-2.33.2-3.20: build-template
-
-build-2.33.2-3.19: AWS_CLI_VERSION="2.33.2"
-build-2.33.2-3.19: PYTHON_VERSION="3.12.4"
-build-2.33.2-3.19: ALPINE_VERSION="3.19"
-build-2.33.2-3.19: build-template
-
-build-2.31.17-3.20: AWS_CLI_VERSION="2.31.17"
-build-2.31.17-3.20: PYTHON_VERSION="3.12.4"
-build-2.31.17-3.20: ALPINE_VERSION="3.20"
-build-2.31.17-3.20: build-template
-
-build-2.31.17-3.19: AWS_CLI_VERSION="2.31.17"
-build-2.31.17-3.19: PYTHON_VERSION="3.12.4"
-build-2.31.17-3.19: ALPINE_VERSION="3.19"
-build-2.31.17-3.19: build-template
 
 build-template:
 	docker buildx build --load . \

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Docker image for AWS-CLI v2 on Alpine Linux.
 You can import the compiled binary created in this image in your Alpine Linux image.
 
 ```bash
-FROM ghcr.io/sparkfabrik/docker-alpine-aws-cli:2.33.2-alpine3.20 as awscli
+FROM ghcr.io/sparkfabrik/docker-alpine-aws-cli:2.35.15-alpine3.23 as awscli
 
-FROM alpine:3.20
+FROM alpine:3.23
 # Install AWS CLI v2 using the binary builded in the awscli stage
 COPY --from=awscli /usr/local/aws-cli/ /usr/local/aws-cli/
 RUN ln -s /usr/local/aws-cli/v2/current/bin/aws /usr/local/bin/aws \


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @Monska85._

## Summary

- Bump the latest AWS CLI from 2.33.2 to 2.35.15.
- Add Alpine 3.23 as the primary base, replacing Alpine 3.19. Alpine 3.20 is kept.
- The build matrix now covers AWS CLI 2.35.15 and 2.33.2, each on Alpine 3.23 and 3.20 (four builds).
- Add an AGENTS.md file (with a CLAUDE.md symlink) documenting the build conventions, version pinning locations, and build gotchas.

## Why the setuptools pin

Alpine 3.23 ships a Python 3.12 image with setuptools 74 or newer, which no longer provides the distutils shim that aws-cli's make-exe still imports. Without a fix the build fails with "ModuleNotFoundError: No module named 'distutils'". The builder now installs setuptools below version 74 to restore it.

## Version pinning notes

- Python is 3.12.13 on Alpine 3.23, because no python:3.12.4-alpine3.23 base image exists. It stays 3.12.4 on Alpine 3.20.
- The three pinned locations (Dockerfile ARG, Makefile, CI matrix) are updated together.

## Verification

All four matrix combinations were built locally with docker buildx and pass the "aws --version" smoke check.

| aws-cli | python | alpine | result |
|---------|--------|--------|--------|
| 2.35.15 | 3.12.13 | 3.23 | ok |
| 2.35.15 | 3.12.4 | 3.20 | ok |
| 2.33.2 | 3.12.13 | 3.23 | ok |
| 2.33.2 | 3.12.4 | 3.20 | ok |

Note: aws-cli 2.33.2 emits a benign "pkg_resources is deprecated" UserWarning on stderr for every command. It is already present in the currently published image, was fixed upstream by the 2.35.x series, and will age out when 2.33.2 leaves the latest-two window.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Bump AWS CLI to 2.35.15, add Alpine 3.23 support, drop 2.31.17 and Alpine 3.19

- Build matrix now covers 2.35.15/2.33.2 on Alpine 3.23/3.20

- Pin `setuptools<74` in Dockerfile to restore `distutils` shim for Alpine 3.23

- Add `AGENTS.md` (with `CLAUDE.md` symlink) documenting build conventions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dockerfile ARG defaults"] -- "bump AWS CLI 2.33.2 -> 2.35.15" --> B["Build matrix"]
  B -- "add Alpine 3.23 / drop 3.19 & 2.31.17" --> C["CI workflow matrix"]
  B -- "add Alpine 3.23 / drop 3.19 & 2.31.17" --> D["Makefile targets"]
  E["Alpine 3.23 Python 3.12 image"] -- "setuptools>=74 removes distutils shim" --> F["pin setuptools<74"]
  F --> A
  G["New docs"] -- "adds" --> H["AGENTS.md + CLAUDE.md symlink"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Bump AWS CLI version and pin setuptools for distutils compatibility</code></dd></summary>
<hr>

Dockerfile

<ul><li>Bump <code>AWS_CLI_VERSION</code> default from <code>2.33.2</code> to <code>2.35.15</code><br> <li> Add <code>pip install --no-cache-dir --break-system-packages "setuptools<74"</code> to <br>restore the <code>distutils</code> shim needed by <code>make-exe</code> on newer Python/Alpine <br>base images</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-alpine-aws-cli/pull/32/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Update build targets for new version/alpine matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Update <code>LATEST_VERSION</code> to <code>2.35.15-alpine3.23</code><br> <li> Change default <code>build</code> target to <code>build-2.35.15-3.23</code><br> <li> Add new targets <code>build-2.35.15-3.23</code>, <code>build-2.35.15-3.20</code>, <br><code>build-2.33.2-3.23</code><br> <li> Remove obsolete targets for <code>2.33.2-3.19</code>, <code>2.31.17-3.20</code>, <code>2.31.17-3.19</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-alpine-aws-cli/pull/32/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+17/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Update CI build matrix for new versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Update <code>test</code> and <code>deploy</code> job matrices to new tag combinations: <br><code>2.35.15-3.12.13-3.23</code>, <code>2.35.15-3.12.4-3.20</code>, <code>2.33.2-3.12.13-3.23</code>, <br><code>2.33.2-3.12.4-3.20</code><br> <li> Remove old combinations referencing Alpine 3.19 and AWS CLI 2.31.17</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-alpine-aws-cli/pull/32/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Add AGENTS.md documenting build conventions and gotchas</code>&nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>New file documenting project overview, setup, conventions, versioning <br>rules, build gotchas, testing, CI/CD, and command safety guidelines<br> <li> Explains the setuptools<74 fix, version pinning locations, and matrix <br>policy</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-alpine-aws-cli/pull/32/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+167/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Add CLAUDE.md pointer to AGENTS.md</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>New symlink-like file pointing to <code>AGENTS.md</code> for Claude agent <br>compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-alpine-aws-cli/pull/32/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

