### PR TITLE
ci(docker): build architectures natively and merge into a multi-arch manifest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,13 +9,19 @@ env:
   RELEASE_BRANCH: main
   REGISTRY: ghcr.io
   IMAGE_NAME: docker-alpine-aws-cli
-  PLATFORMS: "linux/amd64,linux/arm64"
+
+# Least-privilege token: read the repo for checkout, push images to GHCR.
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   test:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
+    name: test ${{ matrix.tag }}
     strategy:
+      fail-fast: false
       matrix:
         tag:
           # To keep the number of builds low, we only keep the latest two versions of the AWS CLI
@@ -24,48 +30,41 @@ jobs:
           - 2.33.2-3.12.13-3.23
           - 2.33.2-3.12.4-3.20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
+      # The test job builds a single native (amd64) image with --load, so it
+      # does not need QEMU.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Get variables
         id: vars
         run: |
-          echo "latest_image_tag=$(make print-latest-image-tag)" >> "$GITHUB_OUTPUT"
           echo "aws_cli_version=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[1]}')" >> "$GITHUB_OUTPUT"
           echo "python_version=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[2]}')" >> "$GITHUB_OUTPUT"
           echo "alpine_version=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[3]}')" >> "$GITHUB_OUTPUT"
           echo "static_tag=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[1]}')-alpine$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[3]}')" >> "$GITHUB_OUTPUT"
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=${{ steps.vars.outputs.static_tag }},enable=${{ github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH) }}
-            # set latest tag for main branch and if the static_tag is the latest version configured in the Makefile
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH) && steps.vars.outputs.static_tag == steps.vars.outputs.latest_image_tag }}
-            type=sha,format=long,prefix=${{ steps.vars.outputs.static_tag }}-
-
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           load: true
           push: false
           context: .
+          cache-from: type=gha,scope=${{ matrix.tag }}-amd64
+          cache-to: type=gha,mode=max,scope=${{ matrix.tag }}-amd64
           build-args: |
             AWS_CLI_VERSION=${{ steps.vars.outputs.aws_cli_version }}
             PYTHON_VERSION=${{ steps.vars.outputs.python_version }}
             ALPINE_VERSION=${{ steps.vars.outputs.alpine_version }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.static_tag }}
 
-  deploy:
-    runs-on: ubuntu-latest
+  build:
     if: contains('["refs/heads/main", "refs/heads/master"]', github.ref)
+    runs-on: ${{ matrix.platform.runner }}
+    name: build ${{ matrix.tag }} (${{ matrix.platform.arch }})
     strategy:
+      fail-fast: false
       matrix:
         tag:
           # To keep the number of builds low, we only keep the latest two versions of the AWS CLI
@@ -73,32 +72,112 @@ jobs:
           - 2.35.15-3.12.4-3.20
           - 2.33.2-3.12.13-3.23
           - 2.33.2-3.12.4-3.20
+        # Each platform is a self-contained object (name/runner/arch) so the
+        # runner and arch are always defined; amd64 builds on ubuntu-latest and
+        # arm64 on a native ubuntu-24.04-arm runner (no QEMU emulation).
+        platform:
+          - name: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - name: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # We use commit sha here to be as safe as possible with credentials.
       - name: Log in to the Container registry
-        uses: docker/login-action@0567fa5ae8c9a197cb207537dc5cbb43ca3d803f
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
+
+      - name: Get variables
+        id: vars
+        run: |
+          echo "aws_cli_version=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[1]}')" >> "$GITHUB_OUTPUT"
+          echo "python_version=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[2]}')" >> "$GITHUB_OUTPUT"
+          echo "alpine_version=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[3]}')" >> "$GITHUB_OUTPUT"
+
+      # Build single-arch and push by digest (no tag); the merge job assembles
+      # the final multi-arch tags from the per-arch digests.
+      - name: Build and push image digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform.name }}
+          cache-from: type=gha,scope=${{ matrix.tag }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.tag }}-${{ matrix.platform.arch }}
+          build-args: |
+            AWS_CLI_VERSION=${{ steps.vars.outputs.aws_cli_version }}
+            PYTHON_VERSION=${{ steps.vars.outputs.python_version }}
+            ALPINE_VERSION=${{ steps.vars.outputs.alpine_version }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ matrix.tag }}-${{ matrix.platform.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [build]
+    if: contains('["refs/heads/main", "refs/heads/master"]', github.ref)
+    runs-on: ubuntu-latest
+    name: merge ${{ matrix.tag }}
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - 2.35.15-3.12.13-3.23
+          - 2.35.15-3.12.4-3.20
+          - 2.33.2-3.12.13-3.23
+          - 2.33.2-3.12.4-3.20
+    steps:
+      - uses: actions/checkout@v7
+
+      # We use commit sha here to be as safe as possible with credentials.
+      - name: Log in to the Container registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          # The full triple differs per tag, so this glob only matches the two
+          # per-arch artifacts of this tag (no cross-tag prefix collision).
+          pattern: digests-${{ matrix.tag }}-*
+          merge-multiple: true
 
       - name: Get variables
         id: vars
         run: |
           echo "latest_image_tag=$(make print-latest-image-tag)" >> "$GITHUB_OUTPUT"
-          echo "aws_cli_version=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[1]}')" >> "$GITHUB_OUTPUT"
-          echo "python_version=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[2]}')" >> "$GITHUB_OUTPUT"
-          echo "alpine_version=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[3]}')" >> "$GITHUB_OUTPUT"
           echo "static_tag=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[1]}')-alpine$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[3]}')" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -107,15 +186,14 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', env.RELEASE_BRANCH) && steps.vars.outputs.static_tag == steps.vars.outputs.latest_image_tag }}
             type=sha,format=long,prefix=${{ steps.vars.outputs.static_tag }}-
 
-      - name: Build Docker image
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          platforms: ${{ env.PLATFORMS }}
-          context: .
-          build-args: |
-            AWS_CLI_VERSION=${{ steps.vars.outputs.aws_cli_version }}
-            PYTHON_VERSION=${{ steps.vars.outputs.python_version }}
-            ALPINE_VERSION=${{ steps.vars.outputs.alpine_version }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create and push multi-arch manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.static_tag }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,17 @@ env:
   RELEASE_BRANCH: main
   REGISTRY: ghcr.io
   IMAGE_NAME: docker-alpine-aws-cli
+  # Single source of truth for the build matrix. Each entry is
+  # <awscli>-<python>-<alpine>; the test, build and merge matrices all read it.
+  # To keep the number of builds low, we only keep the latest two versions of
+  # the AWS CLI.
+  TAGS: >-
+    [
+      "2.35.15-3.12.13-3.23",
+      "2.35.15-3.12.4-3.20",
+      "2.33.2-3.12.13-3.23",
+      "2.33.2-3.12.4-3.20"
+    ]
 
 # Least-privilege token: read the repo for checkout, push images to GHCR.
 permissions:
@@ -16,19 +27,25 @@ permissions:
   packages: write
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.set.outputs.tags }}
+    steps:
+      - id: set
+        # The `env` context is not available to `strategy.matrix` expressions, so
+        # surface TAGS as a job output that downstream matrices can read.
+        run: echo "tags=$(jq -c . <<< "${TAGS}")" >> "$GITHUB_OUTPUT"
+
   test:
+    needs: prepare
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
     name: test ${{ matrix.tag }}
     strategy:
       fail-fast: false
       matrix:
-        tag:
-          # To keep the number of builds low, we only keep the latest two versions of the AWS CLI
-          - 2.35.15-3.12.13-3.23
-          - 2.35.15-3.12.4-3.20
-          - 2.33.2-3.12.13-3.23
-          - 2.33.2-3.12.4-3.20
+        tag: ${{ fromJSON(needs.prepare.outputs.tags) }}
     steps:
       - uses: actions/checkout@v7
 
@@ -60,18 +77,14 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.static_tag }}
 
   build:
+    needs: prepare
     if: contains('["refs/heads/main", "refs/heads/master"]', github.ref)
     runs-on: ${{ matrix.platform.runner }}
     name: build ${{ matrix.tag }} (${{ matrix.platform.arch }})
     strategy:
       fail-fast: false
       matrix:
-        tag:
-          # To keep the number of builds low, we only keep the latest two versions of the AWS CLI
-          - 2.35.15-3.12.13-3.23
-          - 2.35.15-3.12.4-3.20
-          - 2.33.2-3.12.13-3.23
-          - 2.33.2-3.12.4-3.20
+        tag: ${{ fromJSON(needs.prepare.outputs.tags) }}
         # Each platform is a self-contained object (name/runner/arch) so the
         # runner and arch are always defined; amd64 builds on ubuntu-latest and
         # arm64 on a native ubuntu-24.04-arm runner (no QEMU emulation).
@@ -134,18 +147,14 @@ jobs:
           retention-days: 1
 
   merge:
-    needs: [build]
+    needs: [prepare, build]
     if: contains('["refs/heads/main", "refs/heads/master"]', github.ref)
     runs-on: ubuntu-latest
     name: merge ${{ matrix.tag }}
     strategy:
       fail-fast: false
       matrix:
-        tag:
-          - 2.35.15-3.12.13-3.23
-          - 2.35.15-3.12.4-3.20
-          - 2.33.2-3.12.13-3.23
-          - 2.33.2-3.12.4-3.20
+        tag: ${{ fromJSON(needs.prepare.outputs.tags) }}
     steps:
       - uses: actions/checkout@v7
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Each target sets `AWS_CLI_VERSION`, `PYTHON_VERSION`, `ALPINE_VERSION` and calls
 - **Versions are pinned in three places that must agree:**
   - `Dockerfile` `ARG` defaults (`PYTHON_VERSION`, `ALPINE_VERSION`, `AWS_CLI_VERSION`).
   - `Makefile` per-target overrides and `LATEST_VERSION`.
-  - The CI matrix in `.github/workflows/docker-publish.yml` (tag format `<awscli>-<python>-<alpine>`).
+  - The `TAGS` env variable in `.github/workflows/docker-publish.yml` — the single build matrix, one entry per `<awscli>-<python>-<alpine>` triple, consumed by the `test`, `build` and `merge` jobs via `fromJSON`.
     A version bump touches all three.
 - **Keep the build matrix small.** By project policy only the latest two AWS CLI versions are kept (see comments in the Makefile and workflow). Drop the oldest when adding a new one.
 - **AWS CLI v1 lives on the `v2` branch note.** The Dockerfile comment points to a `v2` branch for v2 docs; the current build compiles v2 from the pinned git tag.
@@ -104,7 +104,7 @@ Before bumping any pinned version, verify it against the live source:
    ```
 
 3. **Verify the AWS CLI tag actually builds** on the chosen Python + Alpine combination before committing — the compile step (`make-exe`) is version-sensitive.
-4. **Update all three locations** (Dockerfile ARG, Makefile, CI matrix) in the same change and keep the matrix to the latest two AWS CLI versions.
+4. **Update all three locations** (Dockerfile ARG, Makefile, the workflow `TAGS` variable) in the same change and keep the matrix to the latest two AWS CLI versions.
 
 ## Build Gotchas
 
@@ -127,12 +127,14 @@ GitHub Actions workflow `.github/workflows/docker-publish.yml` (`Docker`), trigg
 
 ### Key Jobs
 
-| Job      | Runs when                   | Purpose                                                                                                                                  |
-| -------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `test`   | ref is not `main`           | Build each matrix tag with `--load`, `push: false` — validates the build.                                                                |
-| `deploy` | ref is `main` (or `master`) | Build for `linux/amd64,linux/arm64` and push to `ghcr.io`. Logs in via `docker/login-action` pinned by commit SHA, using `GITHUB_TOKEN`. |
+| Job       | Runs when                   | Purpose                                                                                                                                                                                           |
+| --------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `prepare` | always                      | Expose the `TAGS` env variable as a JSON output so the `test`, `build` and `merge` matrices all read one list.                                                                                    |
+| `test`    | ref is not `main`           | Build each matrix tag native amd64 with `--load`, `push: false` — validates the build.                                                                                                            |
+| `build`   | ref is `main` (or `master`) | Matrix of `tag × {amd64, arm64}`. Each arch builds on its native runner (`ubuntu-latest` / `ubuntu-24.04-arm`, no QEMU), pushes the image to `ghcr.io` by digest, uploads a digest artifact.      |
+| `merge`   | ref is `main` (or `master`) | Per tag, download the per-arch digests and assemble the multi-arch manifest with `docker buildx imagetools create`. Logs in via `docker/login-action` pinned by commit SHA, using `GITHUB_TOKEN`. |
 
-Tagging (via `docker/metadata-action`): each version gets a `<awscli>-alpine<alpine>` tag; the version matching `LATEST_VERSION` (from `make print-latest-image-tag`) also gets `latest`; every build gets a `sha`-suffixed tag.
+Tagging (via `docker/metadata-action`, in the `merge` job): each version gets a `<awscli>-alpine<alpine>` tag; the version matching `LATEST_VERSION` (from `make print-latest-image-tag`) also gets `latest`; every build gets a `sha`-suffixed tag.
 
 ## Command Safety
 


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @Monska85._

## Summary

Reworks the Docker CI to build each architecture on a native runner and assemble the final image from per-architecture digests, replacing the QEMU-emulated multi-arch build. This mirrors the pattern already in use in `docker-php-drupal-nginx`.

## Why

The previous `deploy` job built `linux/amd64` and `linux/arm64` in a single `buildx` call on an amd64 runner. The arm64 image therefore compiled the AWS CLI v2 from source (the PyInstaller `make-exe` step) under QEMU emulation, which is very slow, and every matrix tag paid that cost serially within its job.

## What changed

- **`build` job** now runs a matrix of `tag × {amd64, arm64}`. amd64 builds on `ubuntu-latest` and arm64 on the native `ubuntu-24.04-arm` runner, so there is no emulation. Each build pushes its image by digest (no tag) and uploads the digest as an artifact.
- **`merge` job** downloads the per-arch digests for each tag and assembles the multi-arch manifest with `docker buildx imagetools create`. `docker/metadata-action` still owns the tag logic (`<awscli>-alpine<alpine>`, `latest` only for `LATEST_VERSION`, and the long-sha tag), so the published tags are identical to before.
- **`test` job** is unchanged in intent: on non-`main` refs it builds a single native amd64 image with `--load` and `push: false` to validate the build.
- Added a `type=gha` build cache scoped per `(tag, arch)`.
- Bumped all actions to their latest releases (checkout v7, setup-buildx v4, build-push v7, login-action v4.4.0 pinned by commit SHA, upload-artifact v7, download-artifact v8, metadata-action v6).

## Note for reviewers

The `ubuntu-24.04-arm` runner must be available to this repository. It is free for public repositories; a private repository would need ARM hosted runners enabled. Worth confirming the first `main` run before relying on it.


___

### **PR Type**
Enhancement


___

### **Description**
- Split `deploy` job into native `build` (matrix over amd64/arm64 runners) and `merge` jobs

- `build` job pushes per-arch images by digest, uploads digest as artifact

- `merge` job downloads digests and assembles multi-arch manifest via `docker buildx imagetools create`

- Removes QEMU emulation for arm64, avoiding slow AWS CLI compile under emulation

- Adds `type=gha` build cache scoped per `(tag, arch)`

- Bumps action versions (checkout v7, setup-buildx v4, build-push v7, login-action pinned SHA, upload/download-artifact v7/v8, metadata-action v6)

- Adds least-privilege `permissions` block (`contents: read`, `packages: write`)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["build job: amd64 (ubuntu-latest)"] -- "push by digest" --> C["digest artifacts"]
  B["build job: arm64 (ubuntu-24.04-arm)"] -- "push by digest" --> C
  C -- "download digests" --> D["merge job"]
  D -- "docker buildx imagetools create" --> E["multi-arch manifest push"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Rework Docker CI to native per-arch builds and manifest merge</code></dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Replaced single <code>deploy</code> job (QEMU multi-arch build) with <code>build</code> job <br>matrixed over <code>tag × platform</code>, using native amd64 (<code>ubuntu-latest</code>) and <br>arm64 (<code>ubuntu-24.04-arm</code>) runners<br> <li> Each <code>build</code> job pushes its image by digest (no tag) and uploads the <br>digest as an artifact via <code>actions/upload-artifact@v7</code><br> <li> New <code>merge</code> job downloads per-arch digests with <br><code>actions/download-artifact@v8</code> and assembles the multi-arch manifest <br>using <code>docker buildx imagetools create</code>, then inspects the final image<br> <li> <code>docker/metadata-action</code> moved to the <code>merge</code> job to compute tags/labels <br>for the final manifest; <code>test</code> job simplified to build a single native <br>amd64 image without metadata-action<br> <li> Added <code>type=gha</code> build cache scoped by <code>(tag, arch)</code>, a least-privilege <br><code>permissions</code> block, and bumped action versions (checkout v7, <br>setup-buildx v4, build-push v7, login-action pinned by SHA, <br>metadata-action v6)</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-alpine-aws-cli/pull/33/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+115/-37</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

