### PR TITLE
ci(docker): restore OCI labels on per-arch images and guard digest count

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -116,6 +116,15 @@ jobs:
           echo "python_version=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[2]}')" >> "$GITHUB_OUTPUT"
           echo "alpine_version=$(echo "${{ matrix.tag }}" | awk '{split($0,a,"-"); print a[3]}')" >> "$GITHUB_OUTPUT"
 
+      # imagetools create only assembles the manifest from tags/digests and does
+      # not add OCI labels, so the labels must be baked into each per-arch image
+      # here (as the previous single-build workflow did).
+      - name: Extract metadata (labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+
       # Build single-arch and push by digest (no tag); the merge job assembles
       # the final multi-arch tags from the per-arch digests.
       - name: Build and push image digest
@@ -130,6 +139,7 @@ jobs:
             AWS_CLI_VERSION=${{ steps.vars.outputs.aws_cli_version }}
             PYTHON_VERSION=${{ steps.vars.outputs.python_version }}
             ALPINE_VERSION=${{ steps.vars.outputs.alpine_version }}
+          labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -198,9 +208,19 @@ jobs:
       - name: Create and push multi-arch manifest
         working-directory: ${{ runner.temp }}/digests
         run: |
+          # Guard the digest set: nullglob turns an empty dir into an empty array
+          # (rather than the literal "*"), and we expect exactly one digest per
+          # architecture in the build matrix (amd64 + arm64). Fail loudly on any
+          # other count instead of feeding a stray file to imagetools create.
+          shopt -s nullglob
+          files=(*)
+          if [ "${#files[@]}" -ne 2 ]; then
+            echo "Expected 2 digest files (amd64, arm64), found ${#files[@]}: ${files[*]}" >&2
+            exit 1
+          fi
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@sha256:%s ' "${files[@]}")
 
       - name: Inspect image
         run: |


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @Monska85._

## Summary

Two follow-ups to the native multi-arch rework merged in #33, addressing the automated reviewer's observations on that PR.

## Restore OCI labels

The previous single-build workflow passed `labels: ${{ steps.meta.outputs.labels }}` to `docker/build-push-action`, so every published image carried its OCI labels (`org.opencontainers.image.created`, `.revision`, `.source`, and so on). After the rework the per-architecture `build` step no longer set `labels`, and `docker buildx imagetools create` in the `merge` job only assembles the manifest list from tags and digests, never applying labels. The result is that published images silently lost that metadata.

This adds `docker/metadata-action` to the `build` job and passes its `labels` output to the build step, baking the labels into each per-arch image the way the old workflow did.

## Guard the digest count

The `merge` job expanded an unfiltered `*` glob to build the digest reference list, so any stray file in the downloaded artifacts directory would become an invalid `image@sha256:` reference and fail with a confusing manifest error. The step now enables `nullglob` (an empty directory fails clearly rather than expanding to the literal `*`), requires exactly two digest files (one per architecture in the matrix), and passes that validated array to `imagetools create`.

## Testing

CI validates the change: the `test` job builds each matrix tag on this PR. The label and merge behaviour exercise only on a `main` build, so it is worth confirming on the first merged run.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Restore OCI labels on per-arch images via `docker/metadata-action` in `build` job

- Pass `labels` output to `build-push-action` so metadata bakes into each arch image

- Guard digest merge with `nullglob` and require exactly two digest files

- Fail loudly if digest count differs from expected amd64/arm64 pair


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["build job: per-arch image"] -- "metadata-action generates labels" --> B["labels applied via build-push-action"]
  B -- "push by digest" --> C["digest artifacts"]
  C -- "download digests" --> D["merge job: nullglob + count guard"]
  D -- "exactly 2 digests required" --> E["docker buildx imagetools create"]
  E -- "assemble" --> F["multi-arch manifest push"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Restore per-arch OCI labels and add digest count guard in merge job</code></dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Added <code>docker/metadata-action@v6</code> step in <code>build</code> job to compute OCI <br>labels per architecture<br> <li> Passed <code>steps.meta.outputs.labels</code> to <code>docker/build-push-action</code> so labels <br>are baked into each per-arch image<br> <li> In <code>merge</code> job, enabled <code>nullglob</code> and collected digest files into an <br>array<br> <li> Added a guard that fails with a clear error unless exactly 2 digest <br>files (amd64, arm64) are found, replacing the unfiltered <code>*</code> glob</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/docker-alpine-aws-cli/pull/34/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+21/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

